### PR TITLE
Trigger a event when content is loaded

### DIFF
--- a/js/jquery.clever-infinite-scroll.js
+++ b/js/jquery.clever-infinite-scroll.js
@@ -142,6 +142,7 @@
               documentHeight = $(document).height();
               $contents = $(settings.contentSelector);
               $("#cis-load-img").remove();
+              $(document).trigger('cleaver-infinite-scroll-content-loaded');
             }
           });
         }


### PR DESCRIPTION
Trigger a event (cleaver-infinite-scroll-content-loaded) to do something with the loaded content.
Maybe enable some jquery plugin =)

Ex.
```
    <script>
        $('article.article-details').cleverInfiniteScroll({
            contentsWrapperSelector: 'article.article-details',
            contentSelector: '.content',
            nextSelector: '#next',
            loadImage: '/assets/img/loading.gif'
        });

        $(document).on('cleaver-infinite-scroll-content-loaded', function () {
            $('.js-slider-article:last').slick({
                slidesToShow: 1,
                slidesToScroll: 1,
                dots: true,
                arrows: false,
                autoplay: false,
                fade: false,
                autoplaySpeed: 3000,
                speed: 700,
                touchThreshold: 15
            });
        });
    </script>
```